### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Reporting Security Issues
+
+To report a security issue, please email
+[oss-security@googlegroups.com](mailto:oss-security@googlegroups.com)
+with a description of the issue, the steps you took to create the issue,
+affected versions, and, if known, mitigations for the issue.
+
+Our vulnerability management team will respond within 3 working days of your
+email. If the issue is confirmed as a vulnerability, we will open a
+Security Advisory and acknowledge your contributions as part of it. This project
+follows a 90 day disclosure timeline.


### PR DESCRIPTION
I just copy/pasted the scorecard policy. 

Not sure if we need to ping the team that manages the email before merging this PR, so they are aware of it :thinking: 